### PR TITLE
[#92] 상품 상세페이지에서 판매자 팔로우 여부 조회 / 팔로우 추가or해제

### DIFF
--- a/src/components/products/ProductDetailInfo.module.css
+++ b/src/components/products/ProductDetailInfo.module.css
@@ -198,7 +198,15 @@
 .followBtn {
   width: 100%;
   padding: 10px 5px;
-
+  color : var(--primary-color);
   background-color: white;
-  border: 1px solid rgb(209, 209, 209);
+  border: 1px solid var(--primary-color);
+  font-weight: bold;
+}
+.followedBtn {
+  width: 100%;
+  padding: 10px 5px;
+  background-color: var(--primary-color);
+  color: white;
+  font-weight: bold;
 }

--- a/src/components/products/ProductDetailInfo.tsx
+++ b/src/components/products/ProductDetailInfo.tsx
@@ -71,6 +71,7 @@ export default function ProductDetailInfo({ id }: { id: string }) {
 	const [showAnimation, setShowAnimation] = useState(false);
 	const isSeller = userInfo.id === productDetail.seller.id; // 판매자 여부
 
+
 	const toggleModal = (name: string) => {
 		if ((name === 'bid' || name === 'report') && !userInfo.id) {
 			router.push(LOGIN_URL);
@@ -130,6 +131,11 @@ export default function ProductDetailInfo({ id }: { id: string }) {
 		const response = await getProductDetail(id, userInfo.id);
 		// console.log(response);
 		setProductDetail(response.data);
+
+		setIsFollow(response.data.follow);
+	}
+	if (productDetail != null) {
+		console.log(productDetail);
 	}
 
 	const images = productDetail.images.map((img: any) => img.imageUrl);
@@ -225,6 +231,20 @@ export default function ProductDetailInfo({ id }: { id: string }) {
 			toast.error(msg || '신고 접수 실패!');
 		}
 	}
+
+	const changeFollowState = async (toId) => {
+		const res = await api.post(`/follow/follower`, { toId: toId, fromId: userInfo.id });
+		const { data: { resultCode, msg } } = res;
+		if (resultCode === '200') {
+			toast.success(msg || '팔로우 상태 변경 성공!');
+		}
+	};
+
+	const [isFollow, setIsFollow] = useState(false);
+
+
+
+
 
 	return (
 		<section className={styles.section} >
@@ -346,7 +366,9 @@ export default function ProductDetailInfo({ id }: { id: string }) {
 							{seller.intro}
 						</div>
 					</Link>
-					{(!isSeller && userInfo.id) && <button className={styles.followBtn}>+ 팔로우</button>}
+					{(!isSeller && userInfo.id && !isFollow)
+						? <button className={styles.followBtn} onClick={() => { setIsFollow(!isFollow); changeFollowState(seller.id); }}>+ 팔로우</button>
+						: <button className={styles.followedBtn} onClick={() => { setIsFollow(!isFollow); changeFollowState(seller.id); }}> 팔로우 해제</button>}
 				</div>
 			</div>
 		</section >

--- a/src/components/products/ProductDetailInfo.tsx
+++ b/src/components/products/ProductDetailInfo.tsx
@@ -131,12 +131,9 @@ export default function ProductDetailInfo({ id }: { id: string }) {
 		const response = await getProductDetail(id, userInfo.id);
 		// console.log(response);
 		setProductDetail(response.data);
-
 		setIsFollow(response.data.follow);
 	}
-	if (productDetail != null) {
-		console.log(productDetail);
-	}
+
 
 	const images = productDetail.images.map((img: any) => img.imageUrl);
 
@@ -370,7 +367,7 @@ export default function ProductDetailInfo({ id }: { id: string }) {
 						<button
 							className={isFollow ? styles.followedBtn : styles.followBtn}
 							onClick={() => { setIsFollow(!isFollow); changeFollowState(seller.id); }}>
-							{isFollow ? '팔로우 해제' : '+팔로우'}
+							{isFollow ? '팔로우 해제' : '+ 팔로우'}
 						</button>
 					)}
 				</div>

--- a/src/components/products/ProductDetailInfo.tsx
+++ b/src/components/products/ProductDetailInfo.tsx
@@ -366,9 +366,13 @@ export default function ProductDetailInfo({ id }: { id: string }) {
 							{seller.intro}
 						</div>
 					</Link>
-					{(!isSeller && userInfo.id && !isFollow)
-						? <button className={styles.followBtn} onClick={() => { setIsFollow(!isFollow); changeFollowState(seller.id); }}>+ 팔로우</button>
-						: <button className={styles.followedBtn} onClick={() => { setIsFollow(!isFollow); changeFollowState(seller.id); }}> 팔로우 해제</button>}
+					{!isSeller && userInfo.id && (
+						<button
+							className={isFollow ? styles.followedBtn : styles.followBtn}
+							onClick={() => { setIsFollow(!isFollow); changeFollowState(seller.id); }}>
+							{isFollow ? '팔로우 해제' : '+팔로우'}
+						</button>
+					)}
 				</div>
 			</div>
 		</section >


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #92 

## 📝작업 내용

> 상품 상세 페이지에서 판매자 팔로우 여부 조회 및 팔로우 추가/해제

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
