### PR TITLE
[#101] Fix 1:1문의 등록시 목록으로 이동 관리자가 1:1문의 조회시 userid 표시대신 email 표시로 변경

### DIFF
--- a/src/app/qna/page.tsx
+++ b/src/app/qna/page.tsx
@@ -42,9 +42,9 @@ export default function Qna() {
 							useRole === 2 ? 
 							<QnaManagerHistory/>
 							:
-							<QnaInquiryHistory />
+							<QnaInquiryHistory/>
 							
-							: <QnaInquiry />
+							: <QnaInquiry qnaContentlist={qnaContentlist}/>
 					}
 				</div>
 			</section >

--- a/src/app/qna/qnainquiry/qnainquiry.tsx
+++ b/src/app/qna/qnainquiry/qnainquiry.tsx
@@ -8,7 +8,7 @@ import toast from "react-hot-toast";
 import { qnaCategories } from "@/app/constants"
 
 
-export default function QnaInquiry() {
+export default function QnaInquiry({qnaContentlist}) {
 	const [qnaContent, setQnaContent] = useState('');
 	const [qnaTitle, setQnaTitle] = useState('');
 	const [categoryId, setCategoryId] = useState('QNA01');
@@ -25,7 +25,7 @@ export default function QnaInquiry() {
 		const res = await api.post(`qnas`, { userId: userId, categoryId: categoryId, qnaTitle: qnaTitle, qnaContent: qnaContent });
 		const { data: { resultCode, msg, data } } = res;
 		if (resultCode == '200') {
-			location.reload();
+			qnaContentlist(1);
 			toast.success(msg || ` `);
 			
 		}

--- a/src/app/qna/qnainquiry/qnainquiry.tsx
+++ b/src/app/qna/qnainquiry/qnainquiry.tsx
@@ -8,12 +8,10 @@ import toast from "react-hot-toast";
 import { qnaCategories } from "@/app/constants"
 
 
-
 export default function QnaInquiry() {
 	const [qnaContent, setQnaContent] = useState('');
 	const [qnaTitle, setQnaTitle] = useState('');
 	const [categoryId, setCategoryId] = useState('QNA01');
-
 	const userInfoValue = useRecoilValue(userInfoState);
 	const userId = userInfoValue.id;
 
@@ -27,8 +25,9 @@ export default function QnaInquiry() {
 		const res = await api.post(`qnas`, { userId: userId, categoryId: categoryId, qnaTitle: qnaTitle, qnaContent: qnaContent });
 		const { data: { resultCode, msg, data } } = res;
 		if (resultCode == '200') {
+			location.reload();
 			toast.success(msg || ` `);
-
+			
 		}
 	}
 	}

--- a/src/app/qna/qnainquiry/qnamanagerhistory.tsx
+++ b/src/app/qna/qnainquiry/qnamanagerhistory.tsx
@@ -159,7 +159,7 @@ function QnaInquiryHistoryBack({list, qnaAnswerContent ,setQnaManagerAnswer ,ins
                         Answer === qna.id &&
                         <div className={styles.qnaHistoryDiv}>
                             <div className={styles.qnaAnswer}>
-                                <div className={styles.qnaAnsWerMail}>유저Id : {qna.userId}</div>
+                                <div className={styles.qnaAnsWerMail}>유저 이메일 : {qna.email}</div>
                             </div>
                             <div className={styles.qnaAnswerContent}>내용: {qna.qnaContent}</div>
                             


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#101
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)
1:1문의 등록시 목록으로 이동 관리자가 1:1문의 조회시 userid 표시대신 email 표시로 변경
## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
