### PR TITLE
[fix]#140 팔로우카드 팔로잉 수 / 상품 수 표시 수정 및 팔로우카드 눌렀을 때, 판매자 페이지 혹은 마이페이지(자신의 팔로우카드 클릭한 경우)로 이동하도록 수정

### DIFF
--- a/src/app/(shop)/shop/[id]/follower/page.tsx
+++ b/src/app/(shop)/shop/[id]/follower/page.tsx
@@ -22,7 +22,6 @@ export default function Follower() {
 		const res = await api.get(`/follow/follower?userId=${userId}&page=${page}&size=10`);
 		const { data: { resultCode, data } } = res;
 		if (resultCode === '200') {
-			console.log(data);
 			setFollowList(list => [...list, ...data.content]);
 			setHasMore(data.content.length > 0);
 

--- a/src/app/(shop)/shop/[id]/follower/page.tsx
+++ b/src/app/(shop)/shop/[id]/follower/page.tsx
@@ -22,6 +22,7 @@ export default function Follower() {
 		const res = await api.get(`/follow/follower?userId=${userId}&page=${page}&size=10`);
 		const { data: { resultCode, data } } = res;
 		if (resultCode === '200') {
+			console.log(data);
 			setFollowList(list => [...list, ...data.content]);
 			setHasMore(data.content.length > 0);
 

--- a/src/app/(shop)/shop/[id]/following/page.tsx
+++ b/src/app/(shop)/shop/[id]/following/page.tsx
@@ -23,6 +23,7 @@ export default function Following() {
 		const res = await api.get(`/follow/following?userId=${userId}&page=${page}&size=10`)
 		const { data: { resultCode, msg, data } } = res;
 		if (resultCode == '200') {
+			console.log(data);
 			setFollowList(list => [...list, ...data.content]);
 			setHasMore(data.content.length > 0);
 			setFollowCnt(data.content.length);

--- a/src/app/(shop)/shop/[id]/following/page.tsx
+++ b/src/app/(shop)/shop/[id]/following/page.tsx
@@ -23,7 +23,7 @@ export default function Following() {
 		const res = await api.get(`/follow/following?userId=${userId}&page=${page}&size=10`)
 		const { data: { resultCode, msg, data } } = res;
 		if (resultCode == '200') {
-			console.log(data);
+
 			setFollowList(list => [...list, ...data.content]);
 			setHasMore(data.content.length > 0);
 			setFollowCnt(data.content.length);

--- a/src/components/products/ProductDetailInfo.tsx
+++ b/src/components/products/ProductDetailInfo.tsx
@@ -240,7 +240,7 @@ export default function ProductDetailInfo({ id }: { id: string }) {
 		const res = await api.post(`/follow/follower`, { toId: toId, fromId: userInfo.id });
 		const { data: { resultCode, msg } } = res;
 		if (resultCode === '200') {
-			toast.success(msg || '팔로우 상태 변경 성공!');
+
 		}
 	};
 

--- a/src/components/shop/followCard.module.css
+++ b/src/components/shop/followCard.module.css
@@ -52,3 +52,6 @@
 	color: white;
 	
 }
+.count {
+	white-space: nowrap; 
+}

--- a/src/components/shop/followCard.tsx
+++ b/src/components/shop/followCard.tsx
@@ -3,31 +3,38 @@ import React, { forwardRef, useEffect, useState } from 'react';
 import FavoriteIcon from '@mui/icons-material/Favorite';
 import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 import { StyledRatingDisabled } from '../StyledRating';
+import Link from 'next/link';
 
 const FollowCard = forwardRef(({ item, index, followState, changeFollowState, userId, storeId }) => {
 
+	console.log(item);
 	return (
 		<div key={index} className={styles.profiles}>
 			<div className={styles.followProfile}>
-				{item.fromMember != null ?
-					<>
-						<img className={styles.profileImg} src={item.fromMember.profileImageUrl} alt={item.fromMember.nickname} />
-						<div className={styles.nickName}>{item.fromMember.nickname}</div>
-					</> :
-					<>
-						<img className={styles.profileImg} src={item.toMember.profileImageUrl} alt={item.toMember.nickname} />
-						<div className={styles.nickName}>{item.toMember.nickname}</div>
-					</>
-				}
-				<div className={styles.rating}><StyledRatingDisabled
-					name="customized-color"
-					defaultValue={item.rating}
-					disabled
-					icon={<FavoriteIcon fontSize="inherit" />}
-					emptyIcon={<FavoriteBorderIcon fontSize="inherit" />}
-					style={{ opacity: 1 }}
-				/></div>
-				<div>상품 {item.productCnt} | 팔로우 {item.followerCnt}</div>
+				<Link href={item.fromMember != null ? (item.fromMember.id != userId ? `/shop/${item.fromMember.id}` : `/shop/${item.fromMember.id}/products`)
+					: (item.toMember.id != userId ? `/shop/${item.toMember.id}` : `/shop/${item.toMember.id}/products`)}>
+					<div>
+						{item.fromMember != null ?
+							<>
+								<img className={styles.profileImg} src={item.fromMember.profileImageUrl} alt={item.fromMember.nickname} />
+								<div className={styles.nickName}>{item.fromMember.nickname}</div>
+							</> :
+							<>
+								<img className={styles.profileImg} src={item.toMember.profileImageUrl} alt={item.toMember.nickname} />
+								<div className={styles.nickName}>{item.toMember.nickname}</div>
+							</>
+						}
+						<div className={styles.rating}><StyledRatingDisabled
+							name="customized-color"
+							defaultValue={item.rating}
+							disabled
+							icon={<FavoriteIcon fontSize="inherit" />}
+							emptyIcon={<FavoriteBorderIcon fontSize="inherit" />}
+							style={{ opacity: 1 }}
+						/></div>
+						<div className={styles.count}>상품 {item.productCnt} | 팔로우 {item.followerCnt}</div>
+					</div>
+				</Link>
 				{userId == 0 ? ""
 					:
 					(item.fromMember != null ?


### PR DESCRIPTION


## #️⃣연관된 이슈

> ex) #140 

## 📝작업 내용

> 팔로우카드 팔로잉 수 / 상품 수 표시 수정 및 팔로우카드 눌렀을 때, 판매자 페이지 혹은 마이페이지(자신의 팔로우카드 클릭한 경우)로 이동하도록 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
